### PR TITLE
SandboxTemplate now needs to call super().init

### DIFF
--- a/cfn-sandbox/cfn-sandbox.py
+++ b/cfn-sandbox/cfn-sandbox.py
@@ -8,6 +8,7 @@ from troposphere import route53
 class SandboxTemplate(Skel):
     def __init__(self, domain):
         self.domain = domain
+        super(SandboxTemplate, self).__init__()
 
     @cfresource
     def hosted_zone(self):


### PR DESCRIPTION
presumably this is due to changes in troposphere and/or troposphere_sugar

The error was as follows:
```
make create-stack
env/bin/python cfn-sandbox.py sandbox.pilosa.com > cfn-sandbox.json
Traceback (most recent call last):
  File "cfn-sandbox.py", line 119, in <module>
    main()
  File "cfn-sandbox.py", line 116, in main
    print SandboxTemplate(domain=domain).output
  File "/Users/jaffee/go/src/github.com/pilosa/infrastructure/cfn-sandbox/env/lib/python2.7/site-packages/troposphere_sugar/skel.py", line 53, in output
    self.process()
  File "/Users/jaffee/go/src/github.com/pilosa/infrastructure/cfn-sandbox/env/lib/python2.7/site-packages/troposphere_sugar/skel.py", line 44, in process
    if not self._processed:
AttributeError: 'SandboxTemplate' object has no attribute '_processed'
make: *** [cfn-sandbox.json] Error 1
```