### PR TITLE
improvements for doing taxi import

### DIFF
--- a/ansible/agent.yml
+++ b/ansible/agent.yml
@@ -47,8 +47,10 @@
           - oci-cli
           - ansible
     - name: set up pilosa hosts environment variable
+      become: yes
+      become_method: sudo
       lineinfile:
-        path: /home/ubuntu/.bashrc
+        path: /etc/profile
         line: "export PILOSA_HOSTS={{ pilosa_hosts }}"
         regexp: "export PILOSA_HOSTS"
       vars:

--- a/ansible/agent.yml
+++ b/ansible/agent.yml
@@ -46,6 +46,13 @@
         packages:
           - oci-cli
           - ansible
+    - name: set up pilosa hosts environment variable
+      lineinfile:
+        path: /home/ubuntu/.bashrc
+        line: "export PILOSA_HOSTS={{ pilosa_hosts }}"
+        regexp: "export PILOSA_HOSTS"
+      vars:
+        pilosa_hosts: "localhost:10101"
 - name: install terraform
   hosts: all
   remote_user: ubuntu

--- a/ansible/demo-taxi.yml
+++ b/ansible/demo-taxi.yml
@@ -14,6 +14,25 @@
         taxi_repo: https://github.com/pilosa/demo-taxi.git
         taxi_version: master
     - name: install
-      command: bash -c 'source /etc/profile.d/go-bin.sh; source /etc/profile.d/go-path.sh; make install'
+      command: bash -c 'source /etc/profile.d/go-bin.sh; source /etc/profile.d/go-path.sh; make install-statik; make install'
       args:
         chdir: /home/ubuntu/go/src/github.com/pilosa/demo-taxi
+    - name: update demo-taxi systemd service
+      become: yes
+      become_method: sudo
+      template:
+        src: "demo-taxi.service.j2"
+        dest: "/etc/systemd/system/demo-taxi.service"
+        mode: 0755
+      vars:
+        pilosa_location: "{{ pilosa_hosts.split(',')[0] }}"
+      notify:
+        - restart demo-taxi
+  handlers:
+    - name: restart demo-taxi
+      become: yes
+      become_method: sudo
+      systemd:
+        name: demo-taxi
+        state: restarted
+        daemon_reload: yes

--- a/ansible/templates/demo-taxi.service.j2
+++ b/ansible/templates/demo-taxi.service.j2
@@ -1,0 +1,24 @@
+[Unit]
+Description=demo-taxi
+After=network.target
+
+[Service]
+Type=simple
+User=ubuntu
+Group=ubuntu
+LimitNOFILE=1048576
+LimitNPROC=1048576
+
+Restart=on-failure
+RestartSec=5
+
+ExecStart=/home/ubuntu/go/bin/demo-taxi --pilosa={{ pilosa_location }}
+
+# make sure log directory exists and owned by syslog
+PermissionsStartOnly=true
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=demo-taxi
+
+[Install]
+WantedBy=multi-user.target

--- a/terraform/examples/oci-pilosa-agent/Makefile
+++ b/terraform/examples/oci-pilosa-agent/Makefile
@@ -1,12 +1,6 @@
 include ../../oci/pilosa/Makefile
 
-PILOSA_PRIVATE_IP=$(shell terraform output -json | jq -r ".pilosa_private_ips.value[$(N)]")
-PILOSA_GOSSIP_SEEDS=$(shell terraform output -json | jq -c "[.pilosa_private_ips.value[] | . + \":14000\"]")
-PILOSA_PUBLIC_IP=$(shell terraform output -json | jq -r ".pilosa_public_ips.value[$(N)]")
-PILOSA_PUBLIC_IPS=$(shell terraform output -json | jq -r ".pilosa_public_ips.value|join(\",\")")
 AGENT_PUBLIC_IP=$(shell terraform output -json | jq -r ".agent_public_ip.value")
-HOSTS=$(PILOSA_PUBLIC_IPS),
-ANSIBLE_ARGS_FINAL=-i $(HOSTS) -e version=$(PILOSA_VERSION) -e gossip_seeds='$(PILOSA_GOSSIP_SEEDS)' $(ANSIBLE_ARGS)
 
 PROVISION = provision-pilosa-agent
 

--- a/terraform/include/Makefile
+++ b/terraform/include/Makefile
@@ -36,7 +36,7 @@ destroy: require-terraform
 	terraform destroy $(TF_ARGS_FINAL)
 
 output: require-terraform
-	terraform output -state=$(TF_STATE) -json
+	@terraform output -state=$(TF_STATE) -json
 
 ssh: require-terraform require-jq
 	ssh -o UserKnownHostsFile=/dev/null \

--- a/terraform/oci/network/securitylists.tf
+++ b/terraform/oci/network/securitylists.tf
@@ -59,6 +59,17 @@ resource "oci_core_security_list" "PilosaSecurityList" {
   }
 
   ingress_security_rules {
+    protocol  = "6"         // tcp
+    source    = "0.0.0.0/0"
+    stateless = false
+
+    tcp_options {
+      "min" = 8000
+      "max" = 8000
+    }
+  }
+
+  ingress_security_rules {
     protocol  = 1
     source    = "0.0.0.0/0"
     stateless = true

--- a/terraform/oci/pilosa/Makefile
+++ b/terraform/oci/pilosa/Makefile
@@ -3,13 +3,14 @@ include ../../include/Makefile
 N=0
 CMD=
 PILOSA_VERSION=master
-PILOSA_PRIVATE_IP=$(shell terraform output -json | jq -r ".private_ips.value[$(N)]")
-PILOSA_GOSSIP_SEEDS=$(shell terraform output -json | jq -c "[.private_ips.value[] | . + \":14000\"]")
-PILOSA_PUBLIC_IP=$(shell terraform output -json | jq -r ".public_ips.value[$(N)]")
-PILOSA_PUBLIC_IPS=$(shell terraform output -json | jq -r ".public_ips.value|join(\",\")")
+PILOSA_PRIVATE_IP=$(shell terraform output -json | jq -r ".pilosa_private_ips.value[$(N)]")
+PILOSA_GOSSIP_SEEDS=$(shell terraform output -json | jq -c "[.pilosa_private_ips.value[] | . + \":14000\"]")
+PILOSA_PUBLIC_IP=$(shell terraform output -json | jq -r ".pilosa_public_ips.value[$(N)]")
+PILOSA_PUBLIC_IPS=$(shell terraform output -json | jq -r ".pilosa_public_ips.value|join(\",\")")
+PILOSA_HOSTS=$(shell terraform output -json | jq -r 'reduce .pilosa_private_ips.value[] as $$item (""; . + $$item + ":10101,") | .[:-1]')
 PUBLIC_IP=$(PILOSA_PUBLIC_IP)
 HOSTS=$(PILOSA_PUBLIC_IPS),
-ANSIBLE_ARGS_FINAL=-i $(HOSTS) -e version=$(PILOSA_VERSION) -e gossip_seeds='$(PILOSA_GOSSIP_SEEDS)' $(ANSIBLE_ARGS)
+ANSIBLE_ARGS_FINAL=-i $(HOSTS) -e version=$(PILOSA_VERSION) -e gossip_seeds='$(PILOSA_GOSSIP_SEEDS)'  -e pilosa_hosts=$(PILOSA_HOSTS) $(ANSIBLE_ARGS)
 
 status: require-terraform
 	$(MAKE) ssh CMD="curl -s $(PILOSA_PRIVATE_IP):10101/status"


### PR DESCRIPTION
set up PILOSA_HOSTS environment var in agent which is useful for running pdk
and demo-taxi

add demo-taxi systemd service to demo-taxi ansible file

removed "shadowed" Makefile vars from downstream makefiles so they get used by
all copies. Also fix upstream vars which were referring to nonexistent keys in
the output.

block extra output from "make output" so it can be piped into jq

open port 8000 in securitylists