### PR TITLE
ability to set disk sizes in GCP

### DIFF
--- a/terraform/examples/gcp-taxi-template/vars.tf
+++ b/terraform/examples/gcp-taxi-template/vars.tf
@@ -42,3 +42,11 @@ variable "pilosa_cluster_size" {
 variable "min_cpu_platform" {
   default = ""
 }
+
+variable "pilosa_disk_size_gb" {
+  default = 200
+}
+
+variable "agent_disk_size_gb" {
+  default = 200
+}

--- a/terraform/examples/gcp-taxi-template/vars.tfvars.example
+++ b/terraform/examples/gcp-taxi-template/vars.tfvars.example
@@ -6,3 +6,5 @@ agent_machine_type="n1-standard-1"
 pilosa_image="ubuntu-os-cloud/ubuntu-1804-lts"
 agent_image="ubuntu-os-cloud/ubuntu-1804-lts"
 pilosa_cluster_size=2
+pilosa_disk_size_gb=200
+agent_disk_size_gb=200

--- a/terraform/gcp/agent/main.tf
+++ b/terraform/gcp/agent/main.tf
@@ -8,6 +8,7 @@ resource "google_compute_instance" "agent" {
   boot_disk {
     initialize_params {
       image = "${var.image}"
+      size = "${var.agent_disk_size_gb}"
     }
   }
 

--- a/terraform/gcp/agent/vars.tf
+++ b/terraform/gcp/agent/vars.tf
@@ -31,3 +31,6 @@ variable "min_cpu_platform" {
   default = ""
 }
 
+variable "agent_disk_size_gb" {
+  default = 200
+}

--- a/terraform/gcp/agent/vars.tfvars.example
+++ b/terraform/gcp/agent/vars.tfvars.example
@@ -5,3 +5,4 @@ network_name="default"
 machine_type="n1-standard-1"
 image="ubuntu-os-cloud/ubuntu-1804-lts"
 ssh_public_key="~/.ssh/id_rsa.pub"
+agent_disk_size_gb=200

--- a/terraform/gcp/pilosa/main.tf
+++ b/terraform/gcp/pilosa/main.tf
@@ -8,6 +8,7 @@ resource "google_compute_instance" "pilosa" {
   boot_disk {
     initialize_params {
       image = "${var.image}"
+      size = "${var.pilosa_disk_size_gb}"
     }
   }
 

--- a/terraform/gcp/pilosa/vars.tf
+++ b/terraform/gcp/pilosa/vars.tf
@@ -33,3 +33,8 @@ variable "pilosa_cluster_size" {
 variable "min_cpu_platform" {
   default = ""
 }
+
+variable "pilosa_disk_size_gb" {
+  default = 200
+}
+

--- a/terraform/gcp/pilosa/vars.tfvars.example
+++ b/terraform/gcp/pilosa/vars.tfvars.example
@@ -4,3 +4,5 @@ region="us-central1"
 machine_type="n1-standard-1"
 image="ubuntu-os-cloud/ubuntu-1804-lts"
 pilosa_cluster_size=2
+pilosa_disk_size_gb=200
+


### PR DESCRIPTION
GCP by default sizes disks based on the OS image, and they are quite
tiny. This gives us good default breathing room, and the ability to
get a larger size if needed.

This just increases the size of the boot partition... if we want to do
anything fancy with NVME or whatever, that will have to be handled
elsewhere.

What I want to avoid is the situation where we stand up some default
infrastructure, start getting a demo or whatever going and then late
in the process find out the disk is full and we need to start over.